### PR TITLE
PlatformIO: Add Headers definitions, align name with Arduino Lib

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,12 +1,13 @@
 {
-    "name": "Thread",
+    "name": "ArduinoThread",
     "keywords": "thread, task",
-    "description": "A library for managing the periodic execution of multiple tasks",
+    "description": "A library for managing the periodic execution of multiple tasks. Forked from ivanseidel/ArduinoThread",
     "repository":
     {
         "type": "git",
-        "url": "https://github.com/ivanseidel/ArduinoThread.git"
+        "url": "https://github.com/meshtastic/ArduinoThread.git"
     },
     "frameworks": "arduino",
+    "headers": ["Thread.h", "ThreadController.h","StaticThreadController.h"],
     "platforms": "atmelavr"
 }


### PR DESCRIPTION
`device-ui` builds fail intermittently when using this library, complaining of "missing Thread.h".

If we explicitly define that this library provides `Thread.h` it seems to resolve the issue.

Also: PlatformIO looks at both library.json and library.properties, so let's align the names.